### PR TITLE
simplified constructor structure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,13 @@ uuid = "275e499e-7a09-5551-a1d1-9fe535a2b717"
 license = "MIT"
 author = "Jeffrey Sarnoff"
 repo = "https://github.com/JeffreySarnoff/FastRationals.jl.git"
-version = "v0.1.6"
+version = "0.1.6"
+
+[deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+
+[compat]
+julia = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,6 +17,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["LinearAlgebra", "Test"]
-
-[compat]
-julia = "1"

--- a/src/FastRationals.jl
+++ b/src/FastRationals.jl
@@ -16,55 +16,46 @@ import Base: BitInteger, BitSigned, hash, show, repr, string, tryparse,
 const SUN = Union{Signed, Unsigned}
 const FastSUN = Union{Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64}
 
-struct FastRational{T} <: Real
+struct FastRational{T<:SUN} <: Real
     num::T
     den::T
     
-    # this constructor is used when den might be <= 0 excluding typemin(T)
-    function FastRational(num::T, den::T) where {T<:SUN}
-        iszero(den) && throw(DivideError)
-        num, den = flipsign(num, den), abs(den)
-        return new{T}(num, den)
+    # this constructor is used when den might be <= 0
+    # the constructor of x assures, that
+    # x.den > 0 and gcd(x.den, x.num) == 1
+    # If due to internal knowledge it is known, that den > 0, the
+    # unchecked constructor below may be used for performance.
+    function FastRational{T}(num::Integer, den::Integer) where T
+        iszero(den) && throw(DivideError())
+        num, den = canonical(T(num), T(den))
+        signbit(den) && throw(DomainError("denominator is typemin($T)"))
+        return new{T}(T(num), T(den))
     end
      
-    # this constructor is used when it is known that den>0   
-    FastRational{T}(num::T, den::T) where {T<:SUN} =
+    # this constructor is used when it is known that den > 0   
+    # no canonicalization and other checks are performed
+    FastRational{T}(num::T, den::T, ::Val{true}) where T =
         new{T}(num, den)
 end
-
-function FastRationalDenomOfT(num::T, den::T) where T<:SUN
-    iszero(den) && throw(DivideError)
-    num, den = flipsign(num, den), abs(den)
-    signbit(den) && throw(DomainError("denominator is typemin($T)"))
-    return FastRational{T}(num, den)
+function FastRational(num::S, den::T) where {S,T}
+    FastRational{promote_type(S,T)}(promote(num, den)...)
 end
-
-function FastRationalDenomNonneg(num::T, den::T) where T<:SUN
-    iszero(den) && throw(DivideError)
-    return FastRational{T}(num, den)
-end
-
-function FastRationalDenomNonzero(num::T, den::T) where T<:SUN
-    num, den = flipsign(num, den), abs(den)
-    signbit(den) && throw(DomainError("denominator is typemin($T)"))
-    return FastRational{T}(num, den)
-end
-
-       
-       # this constructor is used when it is known that den>0   
-    FastRational(numden::Tuple{T, T}) where {T<:SUN} =
-        new{T}(numden[1], numden[2])
-   
-
 const Rationals = Union{FastRational,Rational}
 
-numerator(x::FastRational{T}) where {T<:Integer} = x.num
-denominator(x::FastRational{T}) where {T<:Integer} = x.den
+numerator(x::FastRational) = x.num
+denominator(x::FastRational) = x.den
 
-const FastQ32 = FastRational{Int32}
-const FastQ64 = FastRational{Int64}
-const FastQ128 = FastRational{Int128}
-const FastQBig = FastRational{BigInt}
+# the names `FastQ*` are convencience constructors, not type names.
+for (C, T) in ((:FastQ32, Int32), (:FastQ64, Int64), (:FastQ128, Int128), (:FastQBig, BigInt))
+    
+    @eval begin
+        $C(num, den) = FastRational{$T}(num, den)
+        $C(num) = FastRational{$T}(num)
+        $C(x::Rationals) = FastRational{$T}(x.num, x.den)
+        $C(x::Tuple{<:Integer,<:Integer}) = FastRational{$T}(x[1]//x[2])
+        $C(x::AbstractFloat; tol::Real=eps(x)) = FastRational{$T}(x, tol=tol)
+    end
+end
 
 function canonical(num::T, den::T) where {T<:Signed}
     num, den = flipsign(num, den), abs(den)

--- a/src/promote_convert.jl
+++ b/src/promote_convert.jl
@@ -1,80 +1,23 @@
-# FastRational{T}(num::SUN, den::SUN) wh = FastRational(promote(num,den)...)
-#FastRational{T}(num::SUN, den::SUN) where T = FastRational{T}(promote(num,den)...) # has issues (tests fail)
-FastRational{T}(num::Integer, den::Integer) where {T<:Integer} = FastRational{T}(promote(num,den)...)
-
-FastRational(x::Rational{T}) where {T<:SUN} = FastRational{T}(x.num, x.den)
-
-# required for coverage
-for T in (Int8, Int16, Int32, Int64, Int128, BigInt, UInt8, UInt16, UInt32, UInt64, UInt128)
-  @eval FastRational(num::$T, den::$T) = FastRational{$T}(num, den)
-end
-
-FastRational{FQ}(x::BQ) where {FQ<:Integer, BQ<:Integer} = FastRational(FQ(x.num), one(FQ))
-FastRational{FQ}(x::F; tol=eps(float(x)/2)) where {FQ<:Integer, F<:AbstractFloat} = FastRational(rationalize(x), tol=tol)
-
-Base.Rational{BQ}(x::FastRational{FQ}) where {BQ<:Integer, FQ<:Integer} = Rational(BQ(x.num), BQ(x.den))
-FastRational{FQ}(x::Rational{BQ}) where {FQ<:Integer, BQ<:Integer} = FastRational(FQ(x.num), FQ(x.den))
-
-# this needs to be reworked, leads to ambiguity, but is needed in some recast manner
-# FastRational{I1}(num::I2, den::I2) where {I1<:Integer, I2<:Integer} = FastRational{I1}(I1(num), I1(den))
-FastRational{I}(num::S, den::S) where {I<:Integer, S<:SUN} = FastRational{I}(I(num), I(den))
-
 FastRational{I1}(numden::Tuple{I2,I2}) where {I1<:Integer, I2<:Integer} = FastRational{I1}(numden[1]//numden[2])
-float(x::FastRational{T}) where {T<:Signed} = x.num / x.den
+Base.float(x::FastRational) = x.num / x.den
 
-Base.Float64(x::FastRational{T}) where {T<:Signed}  = float(x)
-Base.Float32(x::FastRational{T}) where {T<:Signed}  = Float32(float(x))I
-Base.Float16(x::FastRational{T}) where {T<:Signed}  = Float16(float(x))
-Base.BigFloat(x::FastRational{T}) where {T<:Signed} = BigFloat(x.num) / BigFloat(x.den)
-Base.BigInt(x::FastRational{T}) where {T<:Signed}   = isinteger(x) ? BigInt((x.num//x.den).num) :
-                                                                         throw(InexactError)
+Base.Float64(x::FastRational) = float(x)
+Base.Float32(x::FastRational) = Float32(float(x))
+Base.Float16(x::FastRational) = Float16(float(x))
+Base.BigFloat(x::FastRational) = BigFloat(x.num) / BigFloat(x.den)
+Base.BigInt(x::FastRational) = isinteger(x) ? BigInt(x.num) ÷ BigInt(x.den) : throw(InexactError())
 
-
-
-function FastRational(x::F) where F<:AbstractFloat
+function FastRational(x::F; tol::Real=eps(x)) where F<:AbstractFloat
     !isfinite(x) && throw(DomainError("finite values only"))
-    return FastRational(rationalize(x))
+    return FastRational(rationalize(x), tol=tol)
 end
-function FastRational{T}(x::F) where {T<:SUN, F<:AbstractFloat}
+function FastRational{T}(x::F; tol::Real=eps(x)) where {T, F<:AbstractFloat}
     !isfinite(x) && throw(DomainError("finite values only"))
-    return FastRational{T}(rationalize(x))
+    return FastRational{T}(rationalize(T, x, tol=tol))
 end
 
-FastQBig(x::Rational{BigInt}) = FastQBig(x.num, x.den)
-FastQBig(x::Rational{T}) where {T<:Signed} = FastQBig(x.num, x.den)
+promote_rule(::Type{FastRational{S}}, ::Type{FastRational{T}}) where {T,S} = FastRational{promote_type(S,T)}
+promote_rule(::Type{FastRational{S}}, ::Type{T}) where {T<:SUN,S} = FastRational{promote_type(S,T)}
+promote_rule(::Type{FastRational{S}}, ::Type{T}) where {T,S} = promote_type(S,T)
+promote_rule(::Type{FastRational{S}}, ::Type{Rational{T}}) where {T,S} = FastRational{promote_type(S,T)}
 
-FastQ128(x::FastQ64) = FastQ128(Rational{Int128}(x.num//x.den))
-FastQ128(x::FastQ32) = FastQ128(Rational{Int128}(x.num//x.den))
-FastQ64(x::FastQ32) = FastQ64(Rational{Int64}(x.num//x.den))
-FastQ32(x::FastQ64) = FastQ32(Rational{Int32}(x.num//x.den))
-FastQ64(x::FastQ128) = FastQ64(Rational{Int64}(x.num//x.den))
-FastQ32(x::FastQ128) = FastQ32(Rational{Int32}(x.num//x.den))
-FastQ64(x::FastQBig) = FastQ64(Rational{Int64}(x.num//x.den))
-FastQ32(x::FastQBig) = FastQ32(Rational{Int32}(x.num//x.den))
-
-promote_rule(::Type{FastQBig}, ::Type{FastQ128}) = FastQBig
-promote_rule(::Type{FastQBig}, ::Type{FastQ64}) = FastQBig
-promote_rule(::Type{FastQBig}, ::Type{FastQ32}) = FastQBig
-promote_rule(::Type{FastQ128}, ::Type{FastQ64}) = FastQ128
-promote_rule(::Type{FastQ128}, ::Type{FastQ32}) = FastQ128
-promote_rule(::Type{FastQ64}, ::Type{FastQ32}) = FastQ64
-convert(::Type{FastQBig}, x::FastQ128) = FastQBig(x)
-convert(::Type{FastQBig}, x::FastQ64) = FastQBig(x)
-convert(::Type{FastQBig}, x::FastQ32) = FastQBig(x)
-convert(::Type{FastQ128}, x::FastQ64) = FastQ128(x)
-convert(::Type{FastQ128}, x::FastQ32) = FastQ128(x)
-convert(::Type{FastQ64}, x::FastQ32) = FastQ64(x)
-convert(::Type{FastQ64}, x::FastQ128) = FastQ64(x)
-convert(::Type{FastQ32}, x::FastQ128) = FastQ32(x)
-convert(::Type{FastQ32}, x::FastQ64) = FastQ32(x)
-
-for (Q,T) in ((:FastQ32, :Int32), (:FastQ64, :Int64), (:FastQ128, :Int128), (:FastQBig, :BigInt))
-  @eval begin
-    promote_rule(::Type{Rational{T}}, ::Type{$Q}) where {T} = $Q
-    convert(::Type{$Q}, x::Rational{T}) where {T} = $Q($T(x.num), $T(x.den))
-    promote_rule(::Type{$Q}, ::Type{F}) where {F<:AbstractFloat} = $Q
-    convert(::Type{$Q}, x::F) where {F<:AbstractFloat} = $Q(Rational{$T}(x))
-    promote_rule(::Type{I}, ::Type{$Q}) where {I<:Integer} = $Q
-    convert(::Type{$Q}, x::I) where {I<:Integer} = $Q($T(x), one($T))
-  end
-end

--- a/test/base_fast.jl
+++ b/test/base_fast.jl
@@ -18,8 +18,8 @@
     @test_throws OverflowError FR(1//2)^63
     =#
     #>>>FIXME @test_throws InexactError -FR(typemin(TI)//1)
-    @test_throws InexactError $FR(typemax($TI)//3) + 1
-    @test_throws InexactError $FR(typemax($TI)//3) * 2
+    @test_throws InexactError $FR(typemax($TI)//3) + $TI(1)
+    @test_throws InexactError $FR(typemax($TI)//3) * $TI(2)
     @test_throws InexactError $FR(1//2)^63
 
     # FIXME!!!
@@ -34,7 +34,7 @@
         end
         if ispow2(b)
             @test $FR(a//b) == $FR(a/b)
-            @test convert($FR,a/b) == $FR(a//b)
+            @test convert(FastRational{$TI}, a/b) == $FR(a//b)
         end
         # @test rationalize(a/b) == a//b
         @test $FR(a//b) == a//b
@@ -68,7 +68,7 @@
     @test 1/5 ≈ float($FR(1//5))
 
     # PR 29561
-    @test abs(one($FR)) === one($FR)
-    @test abs(-one($FR)) === one($FR)
+    @test abs(one(FastRational{$TI})) === one(FastRational{$TI})
+    @test abs(-one(FastRational{$TI})) === one(FastRational{$TI})
   end      
 end

--- a/test/more_fast.jl
+++ b/test/more_fast.jl
@@ -8,7 +8,7 @@
         @test_throws DivideError inv(mx)
         @test FR(typemin(Ti) + 10000) - FR(10000) == mx
         my = FR(typemin(Ti) + 10000) - FR(10000)
-        @test_throws DivideError 1 / my
+        @test_throws DivideError Ti(1) / my
     end
 
     @testset "avoid overflow during add/subtract $N" begin

--- a/test/more_fast.jl
+++ b/test/more_fast.jl
@@ -1,5 +1,16 @@
 @testset "more $N" for (N, FR, Ti) = (("FastQ32", FastQ32, Int32), ("FastQ64", FastQ64, Int64))
 
+    @testset "constructors $N" begin
+        @test_throws DivideError FR(1, 0)
+        @test_throws DomainError FR(Ti(1), typemin(Ti))
+        @test_throws DomainError FR(1, typemin(Ti))
+        mx = FR(typemin(Ti))
+        @test_throws DivideError inv(mx)
+        @test FR(typemin(Ti) + 10000) - FR(10000) == mx
+        my = FR(typemin(Ti) + 10000) - FR(10000)
+        @test_throws DivideError 1 / my
+    end
+
     @testset "avoid overflow during add/subtract $N" begin
         x =  div(typemax(Ti),6)
         @test FR(17, 2x) + FR(17, 3x) == FR(85, 6x)
@@ -7,8 +18,10 @@
     end
 
     @testset "constructors1 $N" begin
-        @test FR(2,4).num == 2
-        @test FR(2,4).den == 4
+        @test FastRational{Ti}(Ti(2),Ti(4),Val(true)).num == 2
+        @test FastRational{Ti}(Ti(2),Ti(4),Val(true)).den == 4
+        @test FastRational{Ti}(2,4).num == 1
+        @test FastRational{Ti}(2,4).den == 2
         @test FR((2,4)).num == 1
         @test FR((2,4)).den == 2
     end


### PR DESCRIPTION
Reduce radically the number of different constructors.
Improve code coverage.

Perfomance ratios under juliav1.3-DEV.557
```	relative speeds
	 (32)	 (64)

mul:   	 28.7 	 29.5 
muladd:	 21.8 	 21.4 
add:   	 18.9 	 18.7 
poly:  	 14.7 	 27.5 
matmul:	 11.5 	 13.4
matlu: 	 4.9 	 5.9 
matinv:	 3.8 	 3.0 
```
