### PR TITLE
Fix division of two negative FastRational{BigInt}

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1,18 +1,18 @@
 #=
-    when it is known of num::T, den::T 
+    when it is known of num::T, den::T
     or given by construction that
        den > 0
        use FastRational{T}(num, den)
            - skip checking for zero or negative denominator
 
-    when it is known of num::T, den::T 
+    when it is known of num::T, den::T
     or given by construction that
     or may be the case that
        den < 0 && den != typemin(T)
        use FastRationalChecked(num, den)
            - check for zero or negative denominator
-   
-    when it is known of num::T, den::T 
+
+    when it is known of num::T, den::T
     or given by construction that
     or may be the case that
        den == typemin(T)
@@ -82,7 +82,7 @@ flipsign(x::FastRational, y::Real)= signbit(y) ? -x : x
 <(x::FastRational, y::FastRational) = widemul(x.num, y.den) < widemul(x.den, y.num)
 
 cmp(x::FastRational, y::FastRational) = cmp(widemul(x.num, y.den), widemul(x.den, y.num))
-    
+
 function +(x::FastRational{T}, y::FastRational{T}) where T
     num, den, ovf = addovf(x, y)
     !ovf && return FastRational{T}(num, den, Val(true))
@@ -117,6 +117,19 @@ function /(x::FastRational{T}, y::FastRational{T}) where T
     numer, denom = canonical(numer, denom)
     den = denom%T
     0 < den < typemax(T) || throw(DivideError())
+    return FastRational{T}(T(numer), den, Val(true))
+end
+
+function /(x::FastRational{T}, y::FastRational{T}) where {T<:BigInt}
+    num, den, ovf = divovf(x, y)
+    if !ovf
+        den > 0 || throw(DivideError())
+        return FastRational{T}(num, den, Val(true))
+    end
+    numer, denom = divq(widen(x.num), widen(x.den), widen(y.num), widen(y.den))
+    numer, denom = canonical(numer, denom)
+    den = denom%T
+    0 < den || throw(DivideError())
     return FastRational{T}(T(numer), den, Val(true))
 end
 

--- a/test/base_fast.jl
+++ b/test/base_fast.jl
@@ -1,5 +1,5 @@
-@testset "$N" for (N, FR, TI) in (("FastQ32", FastQ32, Int32), ("FastQ64", FastQ64, Int64))
-  @eval begin  
+@testset "$N" for (N, FR, TI) in (("FastQ32", FastQ32, Int32), ("FastQ64", FastQ64, Int64), ("FastQBig", FastQBig, BigInt))
+  @eval begin
     @test $FR(1//1) == 1
     @test $FR(2//2) == 1
     @test $FR(1//1) == 1//1
@@ -10,6 +10,7 @@
     @test $FR(1//2) + $FR(3//4) == $FR(5//4) == 5//4
     @test $FR(1//3) * $FR(3//4) == $FR(1//4) == 1//4
     @test $FR(1//2) / $FR(3//4) == $FR(2//3)
+    @test $FR(-1//1) / $FR(-1//1) == $FR(1//1)
 
     #=
     @test_throws OverflowError -FR(typemin(TI)//1)
@@ -17,15 +18,6 @@
     @test_throws OverflowError FR(typemax(TI)//3) * 2
     @test_throws OverflowError FR(1//2)^63
     =#
-    #>>>FIXME @test_throws InexactError -FR(typemin(TI)//1)
-    @test_throws InexactError $FR(typemax($TI)//3) + $TI(1)
-    @test_throws InexactError $FR(typemax($TI)//3) * $TI(2)
-    @test_throws InexactError $FR(1//2)^63
-
-    # FIXME!!!
-    # @test FR(typemax(TI)//one(TI)) * FR(one(TI)//typemax(TI)) == 1
-    # @test FR(typemax(TI)//one(TI)) / FR(typemax(TI)//one(TI)) == 1
-    # @test FR(one(TI)//typemax(TI)) / FR(one(TI)//typemax(TI)) == 1
 
     for a = -5:5, b = -5:5
         if b == 0
@@ -68,7 +60,22 @@
     @test 1/5 ≈ float($FR(1//5))
 
     # PR 29561
-    @test abs(one(FastRational{$TI})) === one(FastRational{$TI})
-    @test abs(-one(FastRational{$TI})) === one(FastRational{$TI})
-  end      
+    @test abs(one(FastRational{$TI})) == one(FastRational{$TI})
+    @test abs(-one(FastRational{$TI})) == one(FastRational{$TI})
+  end
+end
+
+@testset "$N" for (N, FR, TI) in (("FastQ32 typemax/min", FastQ32, Int32), ("FastQ64 typemax/min", FastQ64, Int64))
+  @eval begin
+
+    @test $FR(typemax($TI)//one($TI)) * $FR(one($TI)//typemax($TI)) == 1
+    @test $FR(typemax($TI)//one($TI)) / $FR(typemax($TI)//one($TI)) == 1
+    @test $FR(one($TI)//typemax($TI)) / $FR(one($TI)//typemax($TI)) == 1
+
+    #>>>FIXME @test_throws InexactError -FR(typemin(TI)//1)
+    @test_throws InexactError $FR(typemax($TI)//3) + $TI(1)
+    @test_throws InexactError $FR(typemax($TI)//3) * $TI(2)
+    @test_throws InexactError $FR(1//2)^63
+
+  end
 end


### PR DESCRIPTION
Currently:
```julia
julia> FastQBig(-1) / FastQBig(-1)
ERROR: MethodError: no method matching typemax(::Type{BigInt})
Closest candidates are:
  typemax(::Type{LibGit2.Consts.GIT_MERGE_FILE_FAVOR}) at Enums.jl:191
  typemax(::Type{MbedTLS.CipherMode}) at Enums.jl:191
  typemax(::Type{Pkg.GitTools.GitMode}) at Enums.jl:191
  ...
Stacktrace:
 [1] /(::FastRational{BigInt}, ::FastRational{BigInt}) at /home/liozou/.julia/dev/FastRationals/src/generic.jl:120
 [2] top-level scope at none:1
```
as with any division of two negative `FastRational{BigInt}`, which hit me today as soon as I tried going from `Rational{BigInt}` to `FastRational{BigInt}`.

This PR fixes this by adding a specialized method for `/(x::FastRational{T}, y::FastRational{T}) where {T<:BigInt}` that simply bypasses the check with `typemax(T)`. It's not a very clever fix, but I could not find another way to implement it that did not have any performance hit. In particular, I tried adding an `isapplicable(typemax, T)` check but `T` was not const-propagated (which is not a surprise I think), or, alternatively, `hasmethod(typemax, Tuple{Type{BigInt}})` but it does not specialize on its arguments. If anyone has any idea, I will gladly update the PR! But in the meantime it does the job.

I added `FastQBig` among the tests (as well as the particular bug this PR fixes). Some tests that were commented out and marked with a `# FIXME!!!` actually work so I uncommented them. Let me know if this is a mistake!