### PR TITLE
Terser fix for negative FastQBig division

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -116,20 +116,7 @@ function /(x::FastRational{T}, y::FastRational{T}) where T
     numer, denom = divq(widen(x.num), widen(x.den), widen(y.num), widen(y.den))
     numer, denom = canonical(numer, denom)
     den = denom%T
-    0 < den < typemax(T) || throw(DivideError())
-    return FastRational{T}(T(numer), den, Val(true))
-end
-
-function /(x::FastRational{T}, y::FastRational{T}) where {T<:BigInt}
-    num, den, ovf = divovf(x, y)
-    if !ovf
-        den > 0 || throw(DivideError())
-        return FastRational{T}(num, den, Val(true))
-    end
-    numer, denom = divq(widen(x.num), widen(x.den), widen(y.num), widen(y.den))
-    numer, denom = canonical(numer, denom)
-    den = denom%T
-    0 < den || throw(DivideError())
+    (Base.hastypemax(T) ? (0 < den < typemax(T)) : (0 < den)) || throw(DivideError())
     return FastRational{T}(T(numer), den, Val(true))
 end
 


### PR DESCRIPTION
> go ahead and PR that rewrite, please

There it is!

This is a code style correction for #25. It should have no performance impact since `T` is const-propagated in `hastypemax` when `T` is either a `Base.BitIntegerType` or `BigInt`. I also checked that `code_llvm` does yield the exact same code for a division of two `FastQBig` before and after this PR, and likewise for two `FastQ64`.