### PR TITLE
Remove unused type-parameter

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -45,7 +45,7 @@ zero(::Type{FastRational{T}}) where T = FastRational{T}(zero(T), one(T), Val(tru
 one(::Type{FastRational{T}}) where T = FastRational{T}(one(T), one(T), Val(true))
 
 iszero(x::FastRational{T}) where T = iszero(x.num)
-isone(x::FastRational) where T = x.num === x.den
+isone(x::FastRational) = x.num === x.den
 isinteger(x::FastRational) = iszero(x.num % x.den)
 function iseven(x::FastRational)
     d, r = divrem(x.num, x.den)


### PR DESCRIPTION
I see the following warning on Julia v1.9, and extraneous type parameters degrade performance.
```julia
┌ FastRationals [275e499e-7a09-5551-a1d1-9fe535a2b717]
│  WARNING: method definition for isone at /home/jishnu/.julia/packages/FastRationals/Hsi5K/src/generic.jl:48 declares type variable T but does not use it.
└  
```