### PR TITLE
Delete unnecessary `ceil()` methods

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6.3'
+          - '1'
 #         - 'nightly'
         os:
           - ubuntu-latest
@@ -22,24 +23,15 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "275e499e-7a09-5551-a1d1-9fe535a2b717"
 license = "MIT"
 author = "Jeffrey Sarnoff"
 repo = "https://github.com/JeffreySarnoff/FastRationals.jl.git"
-version = "0.3.1"
+version = "0.3.2"
 
 [compat]
 julia = "1.6"

--- a/src/conform_to_int.jl
+++ b/src/conform_to_int.jl
@@ -3,13 +3,10 @@ floor(x::FastRational{T}) where {T<:Integer} = FastRational{T}(numerator(floor(T
 trunc(x::FastRational{T}) where {T<:Integer} = FastRational{T}(numerator(trunc(T, x.num//x.den)), one(T))
 round(x::FastRational{T}) where {T<:Integer} = FastRational{T}(numerator(round(T, x.num//x.den)), one(T))
 
-ceil(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = ceil(I, x.num//x.den)
 floor(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = floor(I, x.num//x.den)
 trunc(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = trunc(I, x.num//x.den)
 round(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = round(I, x.num//x.den)
 
-ceil(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = ceil(Integer, x.num//x.den)
-floor(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = floor(Integer, x.num//x.den)
 trunc(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = trunc(Integer, x.num//x.den)
 round(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = round(Integer, x.num//x.den)
 
@@ -30,3 +27,10 @@ round(::Type{Integer}, x::FastRational{T}, ::RoundingMode{:FromZero}) where {T<:
 round(::Type{Integer}, x::FastRational{T}, ::RoundingMode{:Up}) where {T<:Integer} = ceil(T, x.num//x.den)
 round(::Type{Integer}, x::FastRational{T}, ::RoundingMode{:Down}) where {T<:Integer} = floor(T, x.num//x.den)
 round(::Type{Integer}, x::FastRational{T}, ::RoundingMode{:Nearest}) where {T<:Integer} = round(T, x.num//x.den)
+
+# See https://github.com/JeffreySarnoff/FastRationals.jl/pull/31
+@static if VERSION < v"1.11"
+    ceil(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = ceil(I, x.num//x.den)
+    ceil(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = ceil(Integer, x.num//x.den)
+    floor(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = floor(Integer, x.num//x.den)
+end


### PR DESCRIPTION
These cause invalidations and are already defined in Base: https://github.com/JuliaLang/julia/blob/f726949136712f84e8ecfea7429d23e626683c80/base/rounding.jl#L485

Fixes these invalidations seen when loading CurveFit.jl (CC @ChrisRackauckas):
```julia
 inserting ceil(::Type{Integer}, x::FastRationals.FastRational{T}) where T<:Integer @ FastRationals ~/.julia/dev/FastRationals/src/conform_to_int.jl:11 invalidated:
   mt_backedges: 1: signature Tuple{typeof(ceil), Type{Integer}, Any} triggered MethodInstance for ceil(::Type{Integer}, ::ForwardDiff.Dual) (0 children)
                 2: signature Tuple{typeof(ceil), Type{Integer}, Any} triggered MethodInstance for Base.top_set_bit(::Integer) (73 children)
                 3: signature Tuple{typeof(ceil), Type{Integer}, Any} triggered MethodInstance for Base.top_set_bit(::Unsigned) (1222 children)
   backedges: 1: superseding ceil(::Type{T}, x) where T @ Base rounding.jl:476 with MethodInstance for ceil(::Type{Integer}, ::Any) (77 children)
```

I also took the liberty of bumping the version number, hope that's ok :see_no_evil: 