### PR TITLE
Disable floor() method on 1.11+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "275e499e-7a09-5551-a1d1-9fe535a2b717"
 license = "MIT"
 author = "Jeffrey Sarnoff"
 repo = "https://github.com/JeffreySarnoff/FastRationals.jl.git"
-version = "0.3.2"
+version = "0.3.3"
 
 [compat]
 julia = "1.6"

--- a/src/conform_to_int.jl
+++ b/src/conform_to_int.jl
@@ -3,7 +3,6 @@ floor(x::FastRational{T}) where {T<:Integer} = FastRational{T}(numerator(floor(T
 trunc(x::FastRational{T}) where {T<:Integer} = FastRational{T}(numerator(trunc(T, x.num//x.den)), one(T))
 round(x::FastRational{T}) where {T<:Integer} = FastRational{T}(numerator(round(T, x.num//x.den)), one(T))
 
-floor(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = floor(I, x.num//x.den)
 trunc(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = trunc(I, x.num//x.den)
 round(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = round(I, x.num//x.den)
 
@@ -32,5 +31,6 @@ round(::Type{Integer}, x::FastRational{T}, ::RoundingMode{:Nearest}) where {T<:I
 @static if VERSION < v"1.11"
     ceil(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = ceil(I, x.num//x.den)
     ceil(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = ceil(Integer, x.num//x.den)
+    floor(::Type{I}, x::FastRational{T}) where {I<:Integer, T<:Integer} = floor(I, x.num//x.den)
     floor(::Type{Integer}, x::FastRational{T}) where {T<:Integer} = floor(Integer, x.num//x.den)
 end


### PR DESCRIPTION
On 1.11+ there's already a `floor()` method that defaults to using `round()`. Similar to #31. Fixes these invalidations seen in CurveFit.jl:
```julia
 inserting floor(::Type{I}, x::FastRationals.FastRational{T}) where {I<:Integer, T<:Integer} @ FastRationals ~/.julia/packages/FastRationals/HnIRo/src/conform_to_int.jl:6 invalidated:                                                        
   backedges: 1: superseding floor(::Type{T}, x) where T @ Base rounding.jl:484 with MethodInstance for floor(::Type{Int64}, ::Any) (4 children)                                                                                               
              2: superseding floor(::Type{T}, x) where T @ Base rounding.jl:484 with MethodInstance for floor(::Type{Int64}, ::Any) (119 children)                                                                                             
```

I also took the liberty of bumping the version number.